### PR TITLE
Base32 - strings resulting remaining non-zero bits - treated as invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,22 @@ wbhwfhpnykj77weppsb22upiuddqaf
 ## Conclusion and recommondation
 
 As a compromise between length, readability and case-insensitivity (base64 isn't) I'd go for base32 with the standard RFC4648 alphabet.
+
+## Base32 - Properties of Decode and Encode Functions
+
+The method `Encode` is an injective function, that is each byte array results in a unique encoded string. However, it is not a surjective function. In other words, not every string (in the defined alphabet) has a corresponding byte array whose encoding would result this string.
+On the other hand, in the initial implementation, the function `Decode` is defined for any string in the defined alphabet. 
+In the case of the above mentioned strings, this was made possible by ignoring bits that would remain after the decoding and returning basically a byte array that would result a completely different string at encoding (rows 1-5): 
+
+### Example:
+
+|   | Input string                  | Guid resulting from the Encoding       | Remaining Bits (amount) | Remaining Buffer (binary) | 
+|:-:|:-----------------------------:|:--------------------------------------:|:-----------------------:|:-------------------------:|
+| 1 | `aaaaaaaaaaaaaaaaaaaaaaaaaa`  | `00000000-0000-0000-0000-000000000000` | 0                       | 0                         |
+| 2 | `aaaaaaaaaaaaaaaaaaaaaaaaab`  | `00000000-0000-0000-0000-000000000000` | 1                       | 1                         |
+| 3 | `aaaaaaaaaaaaaaaaaaaaaaaaac`  | `00000000-0000-0000-0000-000000000000` | 2                       | 10                        |
+| 4 | `aaaaaaaaaaaaaaaaaaaaaaaaad`  | `00000000-0000-0000-0000-000000000000` | 3                       | 11                        |
+| 5 | `aaaaaaaaaaaaaaaaaaaaaaaaaaa` | `00000000-0000-0000-0000-000000000000` | 7                       | 0                         |
+| 6 | `aaaaaaaaaaaaaaaaaaaaaaaaae`  | `00000000-0000-0000-0000-000000000001` | 0                       | 0                         | 
+
+Since we wish the functions `Encoode` and `Decode` to be the exact inverse functions of each other, we shall limit the domain of the `Decode` method - by ruling out such string as invalid input (rows 2-5).

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ As a compromise between length, readability and case-insensitivity (base64 isn't
 
 The method `Encode` is an injective function, that is each byte array results in a unique encoded string. However, it is not a surjective function. In other words, not every string (in the defined alphabet) has a corresponding byte array whose encoding would result this string.
 On the other hand, in the initial implementation, the function `Decode` is defined for any string in the defined alphabet. 
-In the case of the above mentioned strings, this was made possible by ignoring bits that would remain after the decoding and returning basically a byte array that would result a completely different string at encoding (rows 1-5): 
+In the case of the above mentioned strings, this was made possible by ignoring bits that would remain after the decoding and returning basically a byte array that would result a completely different string at encoding. As a result `Decode` is not an injectve function, in other words: multiple strings can result in the same byte array (rows 1-5): 
 
 ### Example:
 
-|   | Input string                  | Guid resulting from the Encoding       | Remaining Bits (amount) | Remaining Buffer (binary) | 
+|   | Input string                  | Guid resulting from the Decoding       | Remaining Bits (amount) | Remaining Buffer (binary) | 
 |:-:|:-----------------------------:|:--------------------------------------:|:-----------------------:|:-------------------------:|
 | 1 | `aaaaaaaaaaaaaaaaaaaaaaaaaa`  | `00000000-0000-0000-0000-000000000000` | 0                       | 0                         |
 | 2 | `aaaaaaaaaaaaaaaaaaaaaaaaab`  | `00000000-0000-0000-0000-000000000000` | 1                       | 1                         |

--- a/src/uuid-encoding/Base32.cs
+++ b/src/uuid-encoding/Base32.cs
@@ -82,6 +82,14 @@ namespace uuid_encoding
                     bitsLeft -= 8;
                 }
             }
+
+            // Ramaing bits lead to ambiguity, since different input strings lead to the same 
+            // result when ignoring those bits) 
+            if ((buffer & ((1 << bitsLeft) - 1)) != 0)
+            {
+                throw new DecodingException("Remaining bits: " + bitsLeft);
+            }
+
             // We'll ignore leftover bits for now.
             //
             // if (next != outLength || bitsLeft >= SHIFT) {

--- a/src/uuid-encoding/Base32.cs
+++ b/src/uuid-encoding/Base32.cs
@@ -83,18 +83,20 @@ namespace uuid_encoding
                 }
             }
 
-            // Ramaing bits lead to ambiguity, since different input strings lead to the same 
-            // result when ignoring those bits) 
-            if ((buffer & ((1 << bitsLeft) - 1)) != 0)
+            int remainingBuffer = buffer & ((1 << bitsLeft) - 1);
+
+            // Remaining non-zero buffer as well as left bits amount being at least the shift size lead to 
+            // ambiguity, since different input strings lead to the same result when simply ignoring those.
+            if (remainingBuffer != 0)
             {
-                throw new DecodingException("Remaining bits: " + bitsLeft);
+               throw new DecodingException("Remaining buffer: " + remainingBuffer);
             }
 
-            // We'll ignore leftover bits for now.
-            //
-            // if (next != outLength || bitsLeft >= SHIFT) {
-            //  throw new DecodingException("Bits left: " + bitsLeft);
-            // }
+            if (next != outLength || bitsLeft >= SHIFT)
+            {
+               throw new DecodingException("Bits left: " + bitsLeft);
+            }
+
             return result;
         }
 

--- a/test/Base32Tests.cs
+++ b/test/Base32Tests.cs
@@ -82,13 +82,11 @@ namespace uuid_encoding.Tests
         public void TestSmallDecodingsAndFailures() 
         {
             // decoded, but not enough to return any bytes.
-            Assert.That(0, Is.EqualTo(Base32.Decode("A").Length));
             Assert.That(0, Is.EqualTo(Base32.Decode("").Length));
             Assert.That(0, Is.EqualTo(Base32.Decode(" ").Length));
 
             // decoded successfully and returned 1 byte.
             Assert.That(1, Is.EqualTo(Base32.Decode("AA").Length));
-            Assert.That(1, Is.EqualTo(Base32.Decode("AAA").Length));
 
             // decoded successfully and returned 2 bytes.
             Assert.That(2, Is.EqualTo(Base32.Decode("AAAA").Length));
@@ -112,9 +110,15 @@ namespace uuid_encoding.Tests
             Assert.Throws<Base32.DecodingException>(() => Base32.Decode("AAA."));
             Assert.Throws<Base32.DecodingException>(() => Base32.Decode("AAA!"));
 
-            // decoding that results remainging bits should fail
+            // decoding that results remainging bits amount at least the shift size should fail
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("A"));
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("AAA"));
             Assert.Throws<Base32.DecodingException>(() => Base32.Decode("77777777777777777"));
-            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("ogbqtedleutexg6pagehf43f63"));
+
+            // decoding that results emaining non-zero buffer
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("aaaaaaaaaaaaaaaaaaaaaaaaab"));
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("aaaaaaaaaaaaaaaaaaaaaaaaac"));
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("aaaaaaaaaaaaaaaaaaaaaaaaad"));
 
             // this just documents that a null string causes a nullpointerexception.
             Assert.Throws<System.NullReferenceException>(() => Base32.Decode(null));

--- a/test/Base32Tests.cs
+++ b/test/Base32Tests.cs
@@ -60,19 +60,23 @@ namespace uuid_encoding.Tests
         }
 
         /**
+        * UPDATE: With the intruduction of the remaining-bits validation, 
+        * the 17s is no longer a valid input as it has remaining 5 bits after the decoding.
+        * Therefre the ambiguity with the 16 7s input.
+        * ============================================================================
         * Base32String implementation is not the same as that of RFC 4648, it drops
         * the last incomplete chunk and thus accepts encoded strings that should have
         * been rejected; also this results in multiple encoded strings being decoded
         * to the same byte array.
         * This test will catch any changes made regarding this behavior.
         */
-        [Test]
-        public void TestAmbiguousDecoding() 
-        {
-            byte[] b16 = Base32.Decode("7777777777777777"); // 16 7s.
-            byte[] b17 = Base32.Decode("77777777777777777"); // 17 7s.
-            Assert.That(b16, Is.EqualTo(b17));
-        }
+        //[Test]
+        //public void TestAmbiguousDecoding() 
+        //{
+        //    byte[] b16 = Base32.Decode("7777777777777777"); // 16 7s.
+        //    byte[] b17 = Base32.Decode("77777777777777777"); // 17 7s.
+        //    Assert.That(b16, Is.EqualTo(b17));
+        //}
 
         [Test]
         public void TestSmallDecodingsAndFailures() 
@@ -107,6 +111,10 @@ namespace uuid_encoding.Tests
             Assert.Throws<Base32.DecodingException>(() => Base32.Decode("AAA;"));
             Assert.Throws<Base32.DecodingException>(() => Base32.Decode("AAA."));
             Assert.Throws<Base32.DecodingException>(() => Base32.Decode("AAA!"));
+
+            // decoding that results remainging bits should fail
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("77777777777777777"));
+            Assert.Throws<Base32.DecodingException>(() => Base32.Decode("ogbqtedleutexg6pagehf43f63"));
 
             // this just documents that a null string causes a nullpointerexception.
             Assert.Throws<System.NullReferenceException>(() => Base32.Decode(null));


### PR DESCRIPTION
* In the existing implementation the decoding of the strings to byte arrays and instantiation of Guids from them results the following::
```
> Input: aaaaaaaaaaaaaaaaaaaaaaaaaa
> Remaining bits: 0
> Output: 00000000-0000-0000-0000-000000000000
> Input: aaaaaaaaaaaaaaaaaaaaaaaaab
> Remaining bits: 1
> Output: 00000000-0000-0000-0000-000000000000
> Input: aaaaaaaaaaaaaaaaaaaaaaaaac
> Remaining bits: 10
> Output: 00000000-0000-0000-0000-000000000000
> Input: aaaaaaaaaaaaaaaaaaaaaaaaad
> Remaining bits: 11
> Output: 00000000-0000-0000-0000-000000000000
> Input: aaaaaaaaaaaaaaaaaaaaaaaaae
> Remaining bits: 0
> Output: 00000000-0000-0000-0000-000000000001
```
* In order to avoid ambiguity, we treat strings that result remaining non-zero bits during the decoding as invalid. Resulting:
_(blank result stands for no decoding was possible)_
```
> Input: aaaaaaaaaaaaaaaaaaaaaaaaaa
> Remaining bits: 0
> Output: 00000000-0000-0000-0000-000000000000
> Input: aaaaaaaaaaaaaaaaaaaaaaaaab
> Remaining bits: 1
> Output: 
> Input: aaaaaaaaaaaaaaaaaaaaaaaaac
> Remaining bits: 10
> Output: 
> Input: aaaaaaaaaaaaaaaaaaaaaaaaad
> Remaining bits: 11
> Output: 
> Input: aaaaaaaaaaaaaaaaaaaaaaaaae
> Remaining bits: 0
> Output: 00000000-0000-0000-0000-000000000001
```
