### PR TITLE
Remove redundant call to `ToCharArray()`

### DIFF
--- a/src/uuid-encoding/Base32.cs
+++ b/src/uuid-encoding/Base32.cs
@@ -70,7 +70,7 @@ namespace uuid_encoding
             int buffer = 0;
             int next = 0;
             int bitsLeft = 0;
-            foreach (char c in encoded.ToCharArray()) {
+            foreach (char c in encoded) {
                 if (!CHAR_MAP.ContainsKey(c)) {
                     throw new DecodingException("Illegal character: " + c);
                 }


### PR DESCRIPTION
SonarQube marked this as a "bug" but it's more like a simple cleanup :)
The change gonna save time for others who are using the updated version of Base32 lib, and running SonarQube analysis.